### PR TITLE
Update Tags to digests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,9 @@ jobs:
   pypi:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
     - name: Build and publish to pypi
-      uses: JRubics/poetry-publish@v2.0
+      uses: JRubics/poetry-publish@7100bd02517e9f82452e6247849042f6c74dde04 # v2.0
       with:
         pypi_token: ${{ secrets.PYPI_TOKEN }}
         plugins: "poetry-dynamic-versioning[plugin]"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM index.docker.io/library/golang:latest@sha256:0f7691253e132744318ff4b02e0824fec9fa4f3b43b08afd1195599660d51521
 
 # Set the Current Working Directory inside the container
 WORKDIR /app


### PR DESCRIPTION
Hey, 
This PR updates Dockerfile and GitHub Actions tags to use digests for improved security and consistency.

Its a good practice to use digests instead of tags for GitHub Actions and
Docker images to ensure that the same image is used across all environments.

You can read more about this on [GitHubs Documentation](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-docker-container-images)

If you prefer to autommate this process, you can use the [Minder](https://cloud.stacklok.com/minder),
a free for open source projects service that can monitor and remind you to update your tags to digests +
a whole lot more.

Disclaimer: I am on the the developers working on Minder, which is an open source project itself.
